### PR TITLE
docs: add checklist and troubleshooting entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Pod / Deployment / Service / Ingress を中心に、アプリケーションをK
 - Kubernetes をこれから学ぶソフトウェアエンジニア/インフラエンジニア
 - 代表的なリソース（Pod/Deployment/Service/Ingress）を扱う必要がある方
 
+## 実務参照の入口
+
+公開版では、トップページからチェックリスト / トラブルシュート導線へ進める入口を用意しています。
+
+- [実務チェックリストとトラブルシュート導線](https://itdojp.github.io/kubernetes-basics-book/appendices/appendix-d/)
+- [基本トラブルシューティング](https://itdojp.github.io/kubernetes-basics-book/chapters/chapter10/)
+
 ## 開発（ローカル）
 
 ### 前提

--- a/book-config.json
+++ b/book-config.json
@@ -169,13 +169,22 @@
         "srcPath": "src/appendices/appendix-c/index.md",
         "docsPath": "docs/appendices/appendix-c/index.md",
         "navPath": "/appendices/appendix-c/"
+      },
+      {
+        "id": "appendix-d",
+        "title": "付録D：実務チェックリストとトラブルシュート導線",
+        "description": "実務適用前チェックと障害切り分けの入口",
+        "order": 16,
+        "srcPath": "src/appendices/appendix-d/index.md",
+        "docsPath": "docs/appendices/appendix-d/index.md",
+        "navPath": "/appendices/appendix-d/"
       }
     ],
     "afterword": {
       "id": "afterword",
       "title": "あとがき",
       "description": "まとめ・次に読む本（運用編への導線）",
-      "order": 16,
+      "order": 17,
       "srcPath": "src/afterword/index.md",
       "docsPath": "docs/afterword/index.md",
       "navPath": "/afterword/"

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -33,6 +33,8 @@ appendices:
     path: "/appendices/appendix-b/"
   - title: "付録C：参考リンク集"
     path: "/appendices/appendix-c/"
+  - title: "付録D：実務チェックリストとトラブルシュート導線"
+    path: "/appendices/appendix-d/"
 
 afterword:
   - title: "あとがき"

--- a/docs/afterword/index.md
+++ b/docs/afterword/index.md
@@ -1,6 +1,6 @@
 ---
 layout: book
-order: 16
+order: 17
 title: "あとがき"
 ---
 # あとがき

--- a/docs/appendices/appendix-d/index.md
+++ b/docs/appendices/appendix-d/index.md
@@ -42,17 +42,17 @@ title: "付録D：実務チェックリストとトラブルシュート導線"
 
 ```bash
 kubectl config current-context
-kubectl -n <namespace> get all
-kubectl -n <namespace> get events --sort-by=.lastTimestamp
-kubectl -n <namespace> describe pod <pod-name>
-kubectl -n <namespace> logs <pod-name>
-kubectl -n <namespace> get svc,endpointslice,ingress
+kubectl -n <ns> get all
+kubectl -n <ns> get events --sort-by=.lastTimestamp
+kubectl -n <ns> describe pod <pod>
+kubectl -n <ns> logs <pod>
+kubectl -n <ns> get svc,endpointslice,ingress
 ```
 
 `events` の時刻順が期待どおりでない場合は、次のように creationTimestamp で並べ替えます。
 
 ```bash
-kubectl -n <namespace> get events --sort-by=.metadata.creationTimestamp
+kubectl -n <ns> get events --sort-by=.metadata.creationTimestamp
 ```
 
 ## 記録と次アクション

--- a/docs/appendices/appendix-d/index.md
+++ b/docs/appendices/appendix-d/index.md
@@ -1,0 +1,71 @@
+---
+layout: book
+order: 16
+title: "付録D：実務チェックリストとトラブルシュート導線"
+---
+# 付録D：実務チェックリストとトラブルシュート導線
+
+この付録は、Kubernetes の基礎を実務に持ち込む前に確認する checklistPack と、問題が起きたときの troubleshootingFlow をまとめたものです。
+作業前の Issue、手順書、またはレビュー依頼に貼り付け、未確認事項を残したまま変更しないための入口として使います。
+
+## 使い方
+
+1. 対象 namespace、クラスタ、アプリケーション、変更内容を明記する。
+2. 「作業前チェックリスト」を埋める。
+3. 問題が出た場合は「トラブルシュートの入口」に沿って、事実と仮説を分けて記録する。
+4. 復旧後に「記録と次アクション」を残す。
+
+## 作業前チェックリスト
+
+| 観点 | 確認すること | 記録欄 |
+| --- | --- | --- |
+| 対象 | クラスタ名、context、namespace、対象リソース名を記録した | |
+| 権限 | ServiceAccount / RBAC / namespace の責任範囲を確認した | |
+| 変更内容 | 適用する YAML、変更理由、期待する状態を説明できる | |
+| 依存関係 | ConfigMap、Secret、Service、Ingress、PVC などの依存先を確認した | |
+| 安全性 | Secret 相当値を Git、Issue、ログへ貼らない方針を確認した | |
+| 戻し方 | `kubectl rollout undo`、前回 manifest、または再適用手順を用意した | |
+| 観測 | `kubectl get`、`describe`、`events`、`logs` で確認する順序を決めた | |
+
+## トラブルシュートの入口
+
+| 症状 | 最初に見るもの | 次に確認すること |
+| --- | --- | --- |
+| Pod が起動しない | `kubectl -n <ns> describe pod <pod>` | Events、ImagePull、Probe、resources、Secret / ConfigMap の参照 |
+| Pod が Pending のまま | `kubectl -n <ns> get pod <pod> -o wide` | node selector、requests、PVC、スケジューリング制約 |
+| アプリが再起動を繰り返す | `kubectl -n <ns> logs <pod> --previous` | 起動引数、環境変数、Probe、依存サービス |
+| Service に到達できない | `kubectl -n <ns> get svc,endpointslice` | selector、targetPort、Pod label、namespace、DNS 名 |
+| Ingress で到達できない | `kubectl -n <ns> describe ingress <name>` | IngressClass、Controller、Service、TLS secret、host / path |
+| 設定変更が反映されない | `kubectl -n <ns> describe deploy <name>` | rollout 状態、ConfigMap / Secret の参照方法、Pod 再作成の有無 |
+
+## 最小コマンドセット
+
+```bash
+kubectl config current-context
+kubectl -n <namespace> get all
+kubectl -n <namespace> get events --sort-by=.lastTimestamp
+kubectl -n <namespace> describe pod <pod-name>
+kubectl -n <namespace> logs <pod-name>
+kubectl -n <namespace> get svc,endpointslice,ingress
+```
+
+`events` の時刻順が期待どおりでない場合は、次のように creationTimestamp で並べ替えます。
+
+```bash
+kubectl -n <namespace> get events --sort-by=.metadata.creationTimestamp
+```
+
+## 記録と次アクション
+
+トラブルシュートの結果は、次の4点に分けて Issue または作業メモへ残します。
+
+- 事実: 実行したコマンド、出力、時刻、対象 namespace
+- 仮説: 何が原因と考えたか、どの証跡で判断したか
+- 対応: 変更した manifest、再起動、ロールバック、確認結果
+- 再発防止: checklist、README、手順書、監視、アラートへ反映する内容
+
+## 関連ページ
+
+- [第10章：基本トラブルシューティング](../../chapters/chapter10/)
+- [付録A：kubectlクイックリファレンス](../appendix-a/)
+- [付録B：マニフェストスニペット集](../appendix-b/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,19 @@ Pod / Deployment / Service / Ingress を中心に、アプリケーションを 
 - [ ] Secret は base64 であって暗号化ではない前提で扱い、Git へ平文相当の値を残さない
 - [ ] Ingress は Controller が必須であり、Ingress API が凍結されていることと Gateway API の位置づけを確認した
 
+## 実務参照の入口
+
+本書を読み進めるときは、章を順番に読むだけでなく、次の導線を使って「確認すること」と「切り分けること」を分けてください。
+
+| 目的 | 参照先 | 使い方 |
+| --- | --- | --- |
+| 作業前に前提をそろえる | [付録D：実務チェックリストとトラブルシュート導線](appendices/appendix-d/) | クラスタ、namespace、権限、マニフェスト、戻し方を確認してから作業する |
+| よく使う kubectl を確認する | [付録A：kubectlクイックリファレンス](appendices/appendix-a/) | `get` / `describe` / `logs` / `events` の入口を素早く引く |
+| YAML の最小形を確認する | [付録B：マニフェストスニペット集](appendices/appendix-b/) | Pod / Deployment / Service / Ingress の雛形を目的別に参照する |
+| 障害切り分けの順序を確認する | [第10章：基本トラブルシューティング](chapters/chapter10/) | 症状、変更点、events、logs、Service 到達性の順に確認する |
+
+実務で利用する場合は、付録Dのチェックリストを作業メモまたは Issue に貼り、未確認事項を残したまま適用しない運用にします。
+
 ## 目次
 - [はじめに](introduction/)
 

--- a/src/appendices/appendix-d/index.md
+++ b/src/appendices/appendix-d/index.md
@@ -1,0 +1,66 @@
+# 付録D：実務チェックリストとトラブルシュート導線
+
+この付録は、Kubernetes の基礎を実務に持ち込む前に確認する checklistPack と、問題が起きたときの troubleshootingFlow をまとめたものです。
+作業前の Issue、手順書、またはレビュー依頼に貼り付け、未確認事項を残したまま変更しないための入口として使います。
+
+## 使い方
+
+1. 対象 namespace、クラスタ、アプリケーション、変更内容を明記する。
+2. 「作業前チェックリスト」を埋める。
+3. 問題が出た場合は「トラブルシュートの入口」に沿って、事実と仮説を分けて記録する。
+4. 復旧後に「記録と次アクション」を残す。
+
+## 作業前チェックリスト
+
+| 観点 | 確認すること | 記録欄 |
+| --- | --- | --- |
+| 対象 | クラスタ名、context、namespace、対象リソース名を記録した | |
+| 権限 | ServiceAccount / RBAC / namespace の責任範囲を確認した | |
+| 変更内容 | 適用する YAML、変更理由、期待する状態を説明できる | |
+| 依存関係 | ConfigMap、Secret、Service、Ingress、PVC などの依存先を確認した | |
+| 安全性 | Secret 相当値を Git、Issue、ログへ貼らない方針を確認した | |
+| 戻し方 | `kubectl rollout undo`、前回 manifest、または再適用手順を用意した | |
+| 観測 | `kubectl get`、`describe`、`events`、`logs` で確認する順序を決めた | |
+
+## トラブルシュートの入口
+
+| 症状 | 最初に見るもの | 次に確認すること |
+| --- | --- | --- |
+| Pod が起動しない | `kubectl -n <ns> describe pod <pod>` | Events、ImagePull、Probe、resources、Secret / ConfigMap の参照 |
+| Pod が Pending のまま | `kubectl -n <ns> get pod <pod> -o wide` | node selector、requests、PVC、スケジューリング制約 |
+| アプリが再起動を繰り返す | `kubectl -n <ns> logs <pod> --previous` | 起動引数、環境変数、Probe、依存サービス |
+| Service に到達できない | `kubectl -n <ns> get svc,endpointslice` | selector、targetPort、Pod label、namespace、DNS 名 |
+| Ingress で到達できない | `kubectl -n <ns> describe ingress <name>` | IngressClass、Controller、Service、TLS secret、host / path |
+| 設定変更が反映されない | `kubectl -n <ns> describe deploy <name>` | rollout 状態、ConfigMap / Secret の参照方法、Pod 再作成の有無 |
+
+## 最小コマンドセット
+
+```bash
+kubectl config current-context
+kubectl -n <namespace> get all
+kubectl -n <namespace> get events --sort-by=.lastTimestamp
+kubectl -n <namespace> describe pod <pod-name>
+kubectl -n <namespace> logs <pod-name>
+kubectl -n <namespace> get svc,endpointslice,ingress
+```
+
+`events` の時刻順が期待どおりでない場合は、次のように creationTimestamp で並べ替えます。
+
+```bash
+kubectl -n <namespace> get events --sort-by=.metadata.creationTimestamp
+```
+
+## 記録と次アクション
+
+トラブルシュートの結果は、次の4点に分けて Issue または作業メモへ残します。
+
+- 事実: 実行したコマンド、出力、時刻、対象 namespace
+- 仮説: 何が原因と考えたか、どの証跡で判断したか
+- 対応: 変更した manifest、再起動、ロールバック、確認結果
+- 再発防止: checklist、README、手順書、監視、アラートへ反映する内容
+
+## 関連ページ
+
+- [第10章：基本トラブルシューティング](../../chapters/chapter10/)
+- [付録A：kubectlクイックリファレンス](../appendix-a/)
+- [付録B：マニフェストスニペット集](../appendix-b/)

--- a/src/appendices/appendix-d/index.md
+++ b/src/appendices/appendix-d/index.md
@@ -37,17 +37,17 @@
 
 ```bash
 kubectl config current-context
-kubectl -n <namespace> get all
-kubectl -n <namespace> get events --sort-by=.lastTimestamp
-kubectl -n <namespace> describe pod <pod-name>
-kubectl -n <namespace> logs <pod-name>
-kubectl -n <namespace> get svc,endpointslice,ingress
+kubectl -n <ns> get all
+kubectl -n <ns> get events --sort-by=.lastTimestamp
+kubectl -n <ns> describe pod <pod>
+kubectl -n <ns> logs <pod>
+kubectl -n <ns> get svc,endpointslice,ingress
 ```
 
 `events` の時刻順が期待どおりでない場合は、次のように creationTimestamp で並べ替えます。
 
 ```bash
-kubectl -n <namespace> get events --sort-by=.metadata.creationTimestamp
+kubectl -n <ns> get events --sort-by=.metadata.creationTimestamp
 ```
 
 ## 記録と次アクション

--- a/src/index.md
+++ b/src/index.md
@@ -23,6 +23,19 @@ Pod / Deployment / Service / Ingress を中心に、アプリケーションを 
 - [ ] Secret は base64 であって暗号化ではない前提で扱い、Git へ平文相当の値を残さない
 - [ ] Ingress は Controller が必須であり、Ingress API が凍結されていることと Gateway API の位置づけを確認した
 
+## 実務参照の入口
+
+本書を読み進めるときは、章を順番に読むだけでなく、次の導線を使って「確認すること」と「切り分けること」を分けてください。
+
+| 目的 | 参照先 | 使い方 |
+| --- | --- | --- |
+| 作業前に前提をそろえる | [付録D：実務チェックリストとトラブルシュート導線](appendices/appendix-d/) | クラスタ、namespace、権限、マニフェスト、戻し方を確認してから作業する |
+| よく使う kubectl を確認する | [付録A：kubectlクイックリファレンス](appendices/appendix-a/) | `get` / `describe` / `logs` / `events` の入口を素早く引く |
+| YAML の最小形を確認する | [付録B：マニフェストスニペット集](appendices/appendix-b/) | Pod / Deployment / Service / Ingress の雛形を目的別に参照する |
+| 障害切り分けの順序を確認する | [第10章：基本トラブルシューティング](chapters/chapter10/) | 症状、変更点、events、logs、Service 到達性の順に確認する |
+
+実務で利用する場合は、付録Dのチェックリストを作業メモまたは Issue に貼り、未確認事項を残したまま適用しない運用にします。
+
 ## 目次
 - [はじめに](introduction/)
 


### PR DESCRIPTION
## Summary
- Add a top-page "実務参照の入口" that links readers to checklist and troubleshooting references.
- Add Appendix D with a practical pre-work checklist, troubleshooting entry table, minimal kubectl command set, and follow-up record template.
- Update book configuration, navigation, and README/public docs so the new appendix appears in the generated site.

Closes #22

## Validation
- `git diff --check`
- `npm run build`
- `npx --yes markdownlint-cli --disable MD013 MD022 MD025 MD029 MD031 MD032 MD034 -- README.md src/index.md src/appendices/appendix-d/index.md docs/index.md docs/appendices/appendix-d/index.md`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-textlint.js docs --fail-on error`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-links.js docs`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-layout-risk.js docs --fail-on error --output /home/devuser/work/CodeX/booksB/.codex-local/tmp/kube-issue22-layout-risk.json`
- `node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-markdown-structure.js docs --fail-on error --output /home/devuser/work/CodeX/booksB/.codex-local/tmp/kube-issue22-markdown-structure.json`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/bundle-kube-issue22 bundle exec jekyll build --config docs/_config.yml --source docs --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/kube-issue22-site/kubernetes-basics-book --baseurl /kubernetes-basics-book`
- Built-site marker smoke for `/`, `/appendices/appendix-d/`, `/appendices/appendix-a/`, and `/chapters/chapter10/`.