### PR TITLE
chore: add local npm QA to Book QA

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -31,7 +31,18 @@ jobs:
         with:
           node-version: '20'
           cache: npm
-          cache-dependency-path: book-formatter/package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            book-formatter/package-lock.json
+
+      - name: Install local npm dependencies
+        run: npm ci
+
+      - name: Local npm security audit
+        run: npm run check:security
+
+      - name: Local npm QA
+        run: npm test
 
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 node_modules/
 dist/
 _site/
+.jekyll-cache/
+.jekyll-metadata
+.bundle/
+vendor/bundle/
+Gemfile.lock
+docs/_site/
+docs/.jekyll-cache/
+docs/.jekyll-metadata
 .DS_Store
 *.log

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Pod / Deployment / Service / Ingress を中心に、アプリケーションをK
 ## 開発（ローカル）
 
 ### 前提
-- Node.js（動作確認: v22）
+- Node.js 20+（CI は Node.js 20 を使用）
 - npm
 
 ### セットアップ
 ```bash
-npm install
+npm ci
 ```
 
 ### src → docs 同期
@@ -35,6 +35,15 @@ npm run sync
 ### ビルド
 ```bash
 npm run build
+```
+
+### 品質チェック
+```bash
+# npm 依存関係のセキュリティ監査
+npm run check:security
+
+# src → docs 同期と dist 生成の確認
+npm test
 ```
 
 ### ローカルプレビュー

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ npm run build
 # npm 依存関係のセキュリティ監査
 npm run check:security
 
-# src → docs 同期と dist 生成の確認
+# src → docs 同期後に未コミット差分が出ないことを確認
+npm run check:docs-sync
+
+# docs 同期差分の確認と dist 生成
 npm test
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -475,9 +475,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "sync": "node scripts/sync-src-to-docs.js",
     "build": "npm run sync && node scripts/node-build.js",
-    "test": "npm run build",
+    "check:docs-sync": "npm run sync && git diff --exit-code -- docs",
+    "test": "npm run check:docs-sync && node scripts/node-build.js",
     "check:security": "npm audit",
     "serve": "cd dist && python3 -m http.server 4000 || python -m http.server 4000",
     "dev": "npm run build && npm run serve"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "sync": "node scripts/sync-src-to-docs.js",
     "build": "npm run sync && node scripts/node-build.js",
+    "test": "npm run build",
+    "check:security": "npm audit",
     "serve": "cd dist && python3 -m http.server 4000 || python -m http.server 4000",
     "dev": "npm run build && npm run serve"
   },


### PR DESCRIPTION
## Summary
- Audit-fix the existing lockfile by updating vulnerable `picomatch` from `2.3.1` to `2.3.2`.
- Add explicit local npm QA scripts: `npm run check:security` for `npm audit`, `npm run check:docs-sync` for `src -> docs` drift detection, and `npm test` for docs sync verification plus `dist` generation.
- Run root `npm ci`, `npm run check:security`, and `npm test` in Book QA, and include `package-lock.json` in the npm cache key.
- Update README to use reproducible `npm ci` and document the security/docs-sync/build QA commands.
- Ignore local Bundler/Jekyll artifacts produced during Pages verification.

## Scope note
- Existing open Issue #13 is about screenshot capture/insertion. This PR does not change screenshot content; it only improves the repository QA gate used by this quality sprint.

## Evidence
- Baseline `npm audit`: 1 high severity vulnerability in `picomatch <=2.3.1`.
- After `npm audit fix`: `npm run check:security` reports 0 vulnerabilities.
- `npm run check:docs-sync` runs `npm run sync` and fails if tracked `docs/` files drift from `src/`.
- `npm test` runs docs-sync verification and then generates `dist` without silently validating uncommitted regenerated `docs/` content.

## Local verification
- `npm ci`
- `npm run check:security`
- `npm run check:docs-sync`
- `npm test`
- Dist smoke: `dist/index.md`, `dist/chapters/chapter01/index.md`, `dist/chapters/chapter10/index.md`, `dist/appendices/appendix-d/index.md`
- Workspace-local Bundler/Jekyll build: `bundle exec jekyll build --source docs --destination _site`
- Built HTML smoke: `_site/index.html`, `_site/chapters/chapter01/index.html`, `_site/chapters/chapter10/index.html`, `_site/appendices/appendix-d/index.html`
- Workflow YAML parse for `.github/workflows/book-qa.yml`
- Pinned `book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`: unicode, textlint, links, layout-risk, markdown-structure
- `git diff --check`