### PR TITLE
fix: 公開内容にUX module metadataを合わせる

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -14,11 +14,11 @@
     "profile": "B",
     "modules": {
       "quickStart": false,
-      "readingGuide": false,
+      "readingGuide": true,
       "checklistPack": true,
       "troubleshootingFlow": true,
       "conceptMap": false,
-      "figureIndex": true,
+      "figureIndex": false,
       "legalNotice": false,
       "glossary": false
     }

--- a/book-formatter-config.json
+++ b/book-formatter-config.json
@@ -14,11 +14,11 @@
     "profile": "B",
     "modules": {
       "quickStart": false,
-      "readingGuide": false,
+      "readingGuide": true,
       "checklistPack": true,
       "troubleshootingFlow": true,
       "conceptMap": false,
-      "figureIndex": true,
+      "figureIndex": false,
       "legalNotice": false,
       "glossary": false
     }


### PR DESCRIPTION
## 概要

公開導入の読み方ガイドと、専用図表索引がない実態に合わせて`book-config.json`を補正します。

- `readingGuide`: `false` → `true`
- `figureIndex`: `true` → `false`

Profile Bの専用`figureIndex`不足はitdojp/it-engineer-knowledge-architecture#215で分離追跡します。

## 検証

- `npm ci`
- `npm test`
- `npm audit`（0 vulnerabilities）
- `git diff --check`

Closes #34
